### PR TITLE
refactor: replace axios with fetch in listing generation

### DIFF
--- a/lib/generateListing.js
+++ b/lib/generateListing.js
@@ -1,6 +1,8 @@
-import axios from 'axios';
-
 export async function generateListing(input) {
-  const res = await axios.post('/api/generate', { input });
-  return res.data;
+  const res = await fetch('/api/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ input }),
+  });
+  return res.json();
 }


### PR DESCRIPTION
## Summary
- replace axios call with native fetch in generateListing helper
- remove unused axios import

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Missing publishableKey for @clerk/nextjs)


------
https://chatgpt.com/codex/tasks/task_e_68a60849dae0832cab6d75e2ff505038