### PR TITLE
refactor: add shared components and hooks

### DIFF
--- a/components/ChatLog.js
+++ b/components/ChatLog.js
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react';
+import { copyToClipboard } from '@/hooks/useChatUtils';
+import ListingRender from './ListingRender';
+
+export default function ChatLog({ messages, loading, error, onFlyer, onModify }) {
+  const listRef = useRef(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!listRef.current) return;
+    listRef.current.scrollTo({ top: listRef.current.scrollHeight, behavior: 'smooth' });
+  }, [messages.length]);
+
+  async function handleCopy(text) {
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  }
+
+  return (
+    <section className="chat-log" ref={listRef}>
+      {messages.map((message, index) => (
+        <div key={index} className={`message ${message.role}`}>
+          <div className="message-content">
+            {message.role === 'user' ? (
+              <span className="user-message">{message.content}</span>
+            ) : (
+              <div className="assistant-message">
+                {message.pretty ? (
+                  <div>
+                    {message.pretty}
+                    {message.pretty.includes('**') && (
+                      <div className="listing-actions">
+                        <div className="primary-actions">
+                          <button className="copy-btn" onClick={() => handleCopy(message.pretty)}>
+                            {copied ? '✅ Copied!' : '📋 Copy Listing'}
+                          </button>
+                          {onFlyer && (
+                            <button className="flyer-btn-small" onClick={() => onFlyer(message.pretty)}>
+                              🎨 Create Flyers
+                            </button>
+                          )}
+                        </div>
+                        {onModify && (
+                          <div className="modification-options">
+                            <h4 className="modify-title">Modify Listing:</h4>
+                            <div className="modify-buttons">
+                              <button className="modify-btn" onClick={() => onModify(message.pretty, 'longer')}>
+                                📝 Make Longer
+                              </button>
+                              <button className="modify-btn" onClick={() => onModify(message.pretty, 'modern')}>
+                                🏢 More Modern
+                              </button>
+                              <button className="modify-btn" onClick={() => onModify(message.pretty, 'country')}>
+                                🌾 More Country
+                              </button>
+                              <button className="modify-btn" onClick={() => onModify(message.pretty, 'luxurious')}>
+                                ✨ More Luxurious
+                              </button>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                ) : message.content && message.content.includes('```') ? (
+                  <ListingRender title="Generated Listing" content={message.content} />
+                ) : (
+                  message.content || 'Generating...'
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      ))}
+      {loading && (
+        <div className="loading">
+          <div className="loading-dots">
+            <span className="dot"></span>
+            <span className="dot"></span>
+            <span className="dot"></span>
+          </div>
+          <div className="loading-text">Generating your listing...</div>
+        </div>
+      )}
+      {error && <div className="error">{error}</div>}
+    </section>
+  );
+}
+

--- a/components/FlyerModal.js
+++ b/components/FlyerModal.js
@@ -1,0 +1,97 @@
+export default function FlyerModal({
+  open,
+  onClose,
+  flyerTypes,
+  setFlyerTypes,
+  generateFlyers,
+  busy,
+  agencyInfo
+}) {
+  if (!open) return null;
+  const {
+    agencyName, setAgencyName,
+    agentEmail, setAgentEmail,
+    agentPhone, setAgentPhone,
+    websiteLink, setWebsiteLink,
+    officeAddress, setOfficeAddress,
+    showSaveConfirmation,
+    saveAgencyInfo
+  } = agencyInfo || {};
+
+  return (
+    <div className="flyer-modal">
+      <div className="flyer-modal-content">
+        <div className="flyer-modal-header">
+          <h2 className="flyer-modal-title">Create Beautiful Flyers</h2>
+          <button className="flyer-modal-close" onClick={onClose}>✕</button>
+        </div>
+
+        <div className="flyer-section">
+          <h3 className="flyer-section-title">Flyer Types</h3>
+          <label className="flyer-checkbox">
+            <input
+              type="checkbox"
+              checked={flyerTypes.standard}
+              onChange={(e) => setFlyerTypes((s) => ({ ...s, standard: e.target.checked }))}
+            />
+            Standard Property Flyer
+          </label>
+          <label className="flyer-checkbox">
+            <input
+              type="checkbox"
+              checked={flyerTypes.openHouse}
+              onChange={(e) => setFlyerTypes((s) => ({ ...s, openHouse: e.target.checked }))}
+            />
+            Open House Flyer
+          </label>
+        </div>
+
+        <div className="flyer-section">
+          <h3 className="flyer-section-title">Agency Details</h3>
+          <input
+            className="flyer-input"
+            placeholder="Agency Name"
+            value={agencyName}
+            onChange={(e) => setAgencyName(e.target.value)}
+          />
+          <input
+            className="flyer-input"
+            placeholder="Agent Email"
+            value={agentEmail}
+            onChange={(e) => setAgentEmail(e.target.value)}
+          />
+          <input
+            className="flyer-input"
+            placeholder="Agent Phone"
+            value={agentPhone}
+            onChange={(e) => setAgentPhone(e.target.value)}
+          />
+          <input
+            className="flyer-input"
+            placeholder="Website Link"
+            value={websiteLink}
+            onChange={(e) => setWebsiteLink(e.target.value)}
+          />
+          <input
+            className="flyer-input"
+            placeholder="Office Address"
+            value={officeAddress}
+            onChange={(e) => setOfficeAddress(e.target.value)}
+          />
+          <button className="flyer-modal-btn secondary" onClick={saveAgencyInfo}>
+            Save Defaults
+          </button>
+          {showSaveConfirmation && <div className="save-confirmation">Saved!</div>}
+        </div>
+
+        <div className="flyer-modal-actions">
+          <button className="flyer-modal-btn cancel" onClick={onClose}>Cancel</button>
+          <button className="flyer-modal-btn primary" onClick={generateFlyers} disabled={busy}>
+            {busy ? 'Generating...' : 'Generate Flyer'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/components/QuestionsModal.js
+++ b/components/QuestionsModal.js
@@ -1,0 +1,64 @@
+export default function QuestionsModal({
+  open,
+  questions = [],
+  currentQuestionIndex,
+  setCurrentQuestionIndex,
+  questionAnswers,
+  setQuestionAnswers,
+  onClose,
+  onSubmit
+}) {
+  if (!open) return null;
+
+  const handleChange = (e) => {
+    const val = e.target.value;
+    setQuestionAnswers((prev) => ({ ...prev, [currentQuestionIndex]: val }));
+  };
+
+  const handleNext = () => {
+    if (currentQuestionIndex < questions.length - 1) {
+      setCurrentQuestionIndex(currentQuestionIndex + 1);
+    } else {
+      onSubmit();
+    }
+  };
+
+  const handlePrev = () => {
+    if (currentQuestionIndex > 0) {
+      setCurrentQuestionIndex(currentQuestionIndex - 1);
+    }
+  };
+
+  return (
+    <div className="questions-modal">
+      <div className="questions-modal-content">
+        <div className="questions-modal-header">
+          <h2 className="questions-modal-title">Additional Information Needed</h2>
+          <button className="questions-modal-close" onClick={onClose}>✕</button>
+        </div>
+        <p className="questions-modal-description">
+          To create a detailed listing, please answer the following questions.
+        </p>
+        <div className="questions-modal-question">
+          <div>Question {currentQuestionIndex + 1} of {questions.length}</div>
+          <h3>{questions[currentQuestionIndex]}</h3>
+          <textarea
+            value={questionAnswers[currentQuestionIndex] || ''}
+            onChange={handleChange}
+            className="questions-modal-textarea"
+          />
+        </div>
+        <div className="questions-modal-actions">
+          <button className="questions-modal-btn cancel" onClick={onClose}>Cancel</button>
+          {currentQuestionIndex > 0 && (
+            <button className="questions-modal-btn secondary" onClick={handlePrev}>Previous</button>
+          )}
+          <button className="questions-modal-btn primary" onClick={handleNext}>
+            {currentQuestionIndex < questions.length - 1 ? 'Next' : 'Submit'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/hooks/useAgencyInfo.js
+++ b/hooks/useAgencyInfo.js
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+
+export default function useAgencyInfo(storageKey = 'listgenie_agency_info') {
+  const [agencyName, setAgencyName] = useState('');
+  const [agentEmail, setAgentEmail] = useState('');
+  const [agentPhone, setAgentPhone] = useState('');
+  const [websiteLink, setWebsiteLink] = useState('');
+  const [officeAddress, setOfficeAddress] = useState('');
+  const [agencyLogo, setAgencyLogo] = useState(null);
+  const [propertyPhotos, setPropertyPhotos] = useState([]);
+  const [primaryColor, setPrimaryColor] = useState('#2d4a3e');
+  const [secondaryColor, setSecondaryColor] = useState('#8b9d83');
+  const [fontStyle, setFontStyle] = useState('modern');
+  const [showPrice, setShowPrice] = useState(true);
+  const [customPrice, setCustomPrice] = useState('$399,900');
+  const [openHouseDate, setOpenHouseDate] = useState('');
+  const [openHouseTime, setOpenHouseTime] = useState('');
+  const [openHouseAddress, setOpenHouseAddress] = useState('');
+  const [useSignatureStyling, setUseSignatureStyling] = useState(false);
+  const [backgroundPattern, setBackgroundPattern] = useState('none');
+  const [propertyDetails, setPropertyDetails] = useState({
+    bedrooms: '',
+    bathrooms: '',
+    sqft: '',
+    yearBuilt: ''
+  });
+  const [propertyHighlights, setPropertyHighlights] = useState({
+    highCeilings: false,
+    crownMolding: false,
+    updatedKitchen: false,
+    lushLandscaping: false,
+    twoCarGarage: false,
+    communityPool: false,
+    solarPanels: false
+  });
+  const [showSaveConfirmation, setShowSaveConfirmation] = useState(false);
+
+  useEffect(() => {
+    const saved = localStorage.getItem(storageKey);
+    if (!saved) return;
+    try {
+      const parsed = JSON.parse(saved);
+      if (parsed.agencyName) setAgencyName(parsed.agencyName);
+      if (parsed.agentEmail) setAgentEmail(parsed.agentEmail);
+      if (parsed.agentPhone) setAgentPhone(parsed.agentPhone);
+      if (parsed.websiteLink) setWebsiteLink(parsed.websiteLink);
+      if (parsed.officeAddress) setOfficeAddress(parsed.officeAddress);
+      if (parsed.agencyLogo) setAgencyLogo(parsed.agencyLogo);
+      if (parsed.propertyPhotos) setPropertyPhotos(parsed.propertyPhotos);
+      if (parsed.primaryColor) setPrimaryColor(parsed.primaryColor);
+      if (parsed.secondaryColor) setSecondaryColor(parsed.secondaryColor);
+      if (parsed.fontStyle) setFontStyle(parsed.fontStyle);
+      if (parsed.showPrice !== undefined) setShowPrice(parsed.showPrice);
+      if (parsed.customPrice) setCustomPrice(parsed.customPrice);
+      if (parsed.openHouseDate) setOpenHouseDate(parsed.openHouseDate);
+      if (parsed.openHouseTime) setOpenHouseTime(parsed.openHouseTime);
+      if (parsed.openHouseAddress) setOpenHouseAddress(parsed.openHouseAddress);
+      if (parsed.useSignatureStyling) setUseSignatureStyling(parsed.useSignatureStyling);
+      if (parsed.backgroundPattern) setBackgroundPattern(parsed.backgroundPattern);
+      if (parsed.propertyDetails) setPropertyDetails(parsed.propertyDetails);
+      if (parsed.propertyHighlights) setPropertyHighlights(parsed.propertyHighlights);
+    } catch (e) {
+      console.log('Error loading saved agency info:', e);
+    }
+  }, [storageKey]);
+
+  const saveAgencyInfo = () => {
+    const data = {
+      agencyName,
+      agentEmail,
+      agentPhone,
+      websiteLink,
+      officeAddress,
+      agencyLogo,
+      propertyPhotos,
+      primaryColor,
+      secondaryColor,
+      fontStyle,
+      showPrice,
+      customPrice,
+      openHouseDate,
+      openHouseTime,
+      openHouseAddress,
+      useSignatureStyling,
+      backgroundPattern,
+      propertyDetails,
+      propertyHighlights
+    };
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(data));
+      setShowSaveConfirmation(true);
+      setTimeout(() => setShowSaveConfirmation(false), 2000);
+    } catch (e) {
+      console.log('Error saving agency info:', e);
+    }
+  };
+
+  return {
+    agencyName, setAgencyName,
+    agentEmail, setAgentEmail,
+    agentPhone, setAgentPhone,
+    websiteLink, setWebsiteLink,
+    officeAddress, setOfficeAddress,
+    agencyLogo, setAgencyLogo,
+    propertyPhotos, setPropertyPhotos,
+    primaryColor, setPrimaryColor,
+    secondaryColor, setSecondaryColor,
+    fontStyle, setFontStyle,
+    showPrice, setShowPrice,
+    customPrice, setCustomPrice,
+    openHouseDate, setOpenHouseDate,
+    openHouseTime, setOpenHouseTime,
+    openHouseAddress, setOpenHouseAddress,
+    useSignatureStyling, setUseSignatureStyling,
+    backgroundPattern, setBackgroundPattern,
+    propertyDetails, setPropertyDetails,
+    propertyHighlights, setPropertyHighlights,
+    showSaveConfirmation,
+    saveAgencyInfo
+  };
+}
+

--- a/hooks/useChatUtils.js
+++ b/hooks/useChatUtils.js
@@ -1,0 +1,62 @@
+import { useCallback } from 'react';
+
+export function stripFences(s = "") {
+  return s
+    .replace(/```json\s*([\s\S]*?)\s*```/gi, "$1")
+    .replace(/```\s*([\s\S]*?)\s*```/gi, "$1")
+    .trim();
+}
+
+// Coerce any LLM output (raw string, fenced JSON, or object) to readable text
+export function coerceToReadableText(raw) {
+  if (!raw) return "";
+
+  // If object-like, try common shapes
+  if (typeof raw === "object") {
+    const candidate = raw?.mls?.body || raw?.mls || raw?.content || raw?.text || raw?.body;
+    if (candidate) return stripFences(String(candidate));
+    try { return stripFences(JSON.stringify(raw, null, 2)); } catch { /* noop */ }
+  }
+
+  const txt = String(raw);
+  // Try to parse JSON
+  try {
+    const j = JSON.parse(stripFences(txt));
+    const candidate = j?.mls?.body || j?.mls || j?.content || j?.text || j?.body;
+    if (candidate) return stripFences(String(candidate));
+    return stripFences(JSON.stringify(j, null, 2));
+  } catch {
+    return stripFences(txt);
+  }
+}
+
+// Detect formatted sections
+export function splitVariants(text) {
+  if (!text) return null;
+  const patterns = [
+    { key: "mls",    rx: /(^|\n)\s*#{0,3}\s*(MLS-?Ready|MLS Ready)\s*\n([\s\S]*?)(?=\n\s*#{0,3}\s*|$)/i },
+    { key: "social", rx: /(^|\n)\s*#{0,3}\s*Social\s*Caption\s*\n([\s\S]*?)(?=\n\s*#{0,3}\s*|$)/i },
+    { key: "luxury", rx: /(^|\n)\s*#{0,3}\s*Luxury\s*Tone\s*\n([\s\S]*?)(?=\n\s*#{0,3}\s*|$)/i },
+    { key: "concise", rx: /(^|\n)\s*#{0,3}\s*Concise(?:\s*Version)?\s*\n([\s\S]*?)(?=\n\s*#{0,3}\s*|$)/i },
+  ];
+  const out = {}; let found = false;
+  for (const { key, rx } of patterns) {
+    const m = text.match(rx);
+    if (m) { out[key] = (m[3] || m[2] || "").trim(); found = true; }
+  }
+  return found ? out : null;
+}
+
+export async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function useCopy() {
+  return useCallback(copyToClipboard, []);
+}
+


### PR DESCRIPTION
## Summary
- add generic ChatLog for displaying conversations with copy, flyer, and modify actions
- provide reusable flyer modal and question modal components
- introduce hooks for agency info state and chat utilities

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a60b72dc10832c9c4ad192f2a5546a