### PR TITLE
Integrate React Query for user plan

### DIFF
--- a/hooks/useUserPlan.js
+++ b/hooks/useUserPlan.js
@@ -1,99 +1,71 @@
 // hooks/useUserPlan.js
-import { useEffect, useState } from "react";
 import { useUser } from "@clerk/nextjs";
+import { useQuery } from "@tanstack/react-query";
 
 export default function useUserPlan() {
   const { isSignedIn, user } = useUser();
-  const [state, setState] = useState({
-    plan: "trial",
-    trialEnd: null,
-    isLoading: true,
-    isInitialized: false
+  const userId = user?.id;
+
+  const enabled = isSignedIn && !!userId;
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ["user-plan", userId],
+    queryFn: async () => {
+      const res = await fetch("/api/user/plan");
+      if (!res.ok) throw new Error("Failed to fetch user plan");
+      return res.json();
+    },
+    enabled,
+    onError: (e) => {
+      if (process.env.NODE_ENV !== "production") {
+        console.error("Error fetching plan:", e);
+      }
+    }
   });
 
-  const refreshPlan = async () => {
-    try {
-      const r = await fetch("/api/user/plan");
-      const j = await r.json();
-      
-      const plan = j?.plan || "trial";
-      const trialEnd = j?.trial_end_date || null;
-      
-      setState(s => ({ 
-        ...s,
-        plan, 
-        trialEnd, 
-        isLoading: false
-      }));
-      
-      console.log("Plan refreshed:", { plan, trialEnd, response: j });
-    } catch (e) {
-      console.error("Error refreshing plan:", e);
-    }
-  };
+  if (!enabled) {
+    return {
+      plan: "expired",
+      trialEnd: null,
+      isPro: false,
+      isTrial: false,
+      isExpired: true,
+      daysLeft: 0,
+      isLoading: false,
+      canGenerate: false,
+      refreshPlan: () => {}
+    };
+  }
 
-  useEffect(() => {
-    let mounted = true;
-    
-    if (!isSignedIn) {
-      setState(s => ({ ...s, isLoading: false, plan: "expired" }));
-      return;
-    }
-
-    (async () => {
-      try {
-        // Initialize user if needed
-        if (!state.isInitialized) {
-          const initRes = await fetch("/api/user/init", { method: "POST" });
-          if (initRes.ok) {
-            setState(s => ({ ...s, isInitialized: true }));
-          }
-        }
-
-        // Get current plan status
-        const r = await fetch("/api/user/plan");
-        const j = await r.json();
-        
-        if (!mounted) return;
-        
-        const plan = j?.plan || "trial";
-        const trialEnd = j?.trial_end_date || null;
-        
-        setState({ 
-          plan, 
-          trialEnd, 
-          isLoading: false,
-          isInitialized: state.isInitialized
-        });
-      } catch (e) {
-        if (!mounted) return;
-        setState((s) => ({ ...s, isLoading: false }));
-      }
-    })();
-    
-    return () => { mounted = false; };
-  }, [isSignedIn, state.isInitialized]);
-
-  const { plan, trialEnd, isLoading, isInitialized } = state;
+  const plan = data?.plan || "trial";
+  const trialEnd = data?.trial_end_date || null;
   const isPro = plan === "pro";
-  const isTrial = plan === "trial" && !!trialEnd && Date.now() <= new Date(trialEnd).getTime();
-  const isExpired = plan === "expired" || (plan === "trial" && trialEnd && Date.now() > new Date(trialEnd).getTime());
-  const canGenerate = isPro || isTrial; // Both trial and paid Pro can generate
+  const isTrial =
+    plan === "trial" && !!trialEnd && Date.now() <= new Date(trialEnd).getTime();
+  const isExpired =
+    plan === "expired" ||
+    (plan === "trial" && trialEnd && Date.now() > new Date(trialEnd).getTime());
+  const canGenerate = isPro || isTrial;
 
   const daysLeft = isTrial
-    ? Math.max(0, Math.ceil((new Date(trialEnd).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
+    ? Math.max(
+        0,
+        Math.ceil(
+          (new Date(trialEnd).getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+        )
+      )
     : 0;
 
-  return { 
-    plan, 
-    trialEnd, 
-    isPro, 
-    isTrial, 
-    isExpired, 
-    daysLeft, 
+  return {
+    plan,
+    trialEnd,
+    isPro,
+    isTrial,
+    isExpired,
+    daysLeft,
     isLoading,
     canGenerate,
-    isInitialized,
-    refreshPlan
+    refreshPlan: refetch
   };
 }
+

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,7 +4,8 @@ import "@/styles/chat.css";
 import "@/styles/flyer-modal.css";
 import "@/styles/components.css";
 import { ClerkProvider, useAuth, useUser } from "@clerk/nextjs";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 
 function InitUserOnce() {
@@ -36,11 +37,15 @@ function InitUserOnce() {
 }
 
 export default function App({ Component, pageProps }) {
+  const [queryClient] = useState(() => new QueryClient());
+
   return (
     <ClerkProvider {...pageProps}>
-      <InitUserOnce />
+      <QueryClientProvider client={queryClient}>
+        <InitUserOnce />
 
-      <Component {...pageProps} />
+        <Component {...pageProps} />
+      </QueryClientProvider>
     </ClerkProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap app with TanStack QueryClientProvider
- refactor user plan hook to use `useQuery` keyed by user ID
- gate error logs behind development checks

## Testing
- `npm ls @tanstack/react-query`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a61883a4fc832c8e730fac672c8cc2