### PR TITLE
refactor: use Next.js Link for internal routes

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -2,6 +2,7 @@
 import React from "react";
 import { SignedIn, SignedOut, SignInButton, UserButton, useUser } from "@clerk/nextjs";
 import useUserPlan from "@/hooks/useUserPlan";
+import Link from "next/link";
 
 export default function NavBar() {
   const { isSignedIn } = useUser();
@@ -31,7 +32,7 @@ export default function NavBar() {
         }}
       >
         {/* Left: brand */}
-        <a href="/" style={{ display: "flex", alignItems: "center", gap: 8, textDecoration: "none", color: "inherit" }}>
+        <Link href="/" style={{ display: "flex", alignItems: "center", gap: 8, textDecoration: "none", color: "inherit" }}>
           <div
             style={{
               width: 34,
@@ -46,13 +47,13 @@ export default function NavBar() {
             🏠
           </div>
           <strong>ListGenie.ai</strong>
-        </a>
+        </Link>
 
         {/* Left: primary nav */}
         <div style={{ display: "flex", gap: 10, marginLeft: 12 }}>
-          <a href="/chat" className="link">Chat</a>
+          <Link href="/chat" className="link">Chat</Link>
           <SignedIn>
-            <a href="/listings" className="link">Listings</a>
+            <Link href="/listings" className="link">Listings</Link>
           </SignedIn>
         </div>
 
@@ -65,7 +66,7 @@ export default function NavBar() {
           </SignedOut>
 
           <SignedIn>
-            {!isPro && <a href="/upgrade" className="link">Upgrade</a>}
+            {!isPro && <Link href="/upgrade" className="link">Upgrade</Link>}
 
             {isPro && (
               <form action="/api/stripe/create-portal-session" method="post" style={{ display: "inline" }}>

--- a/pages/batch.js
+++ b/pages/batch.js
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { SignedIn, SignedOut, SignInButton } from "@clerk/nextjs";
 import useUserPlan from "@/hooks/useUserPlan";
 import NavBar from "@/components/NavBar";
+import Link from "next/link";
 
 export default function BatchPage() {
   return (
@@ -48,7 +49,7 @@ function BatchProcessor() {
           <p style={{ marginBottom: 16, color: "var(--text-dim)" }}>
             Batch processing is available exclusively to Pro users.
           </p>
-          <a href="/upgrade" className="btn">Upgrade to Pro</a>
+          <Link href="/upgrade" className="btn">Upgrade to Pro</Link>
         </div>
       </div>
     );

--- a/pages/chat.js
+++ b/pages/chat.js
@@ -9,6 +9,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import useUserPlan from "@/hooks/useUserPlan";
+import Link from "next/link";
 
 /** ---------------- Utilities ---------------- */
 function stripFences(s = "") {
@@ -1124,9 +1125,9 @@ export default function ChatPage() {
               </button>
             )}
             <div className="navbar-links">
-              <a href="/upgrade" className="billing-link">
+              <Link href="/upgrade" className="billing-link">
                 Billing
-              </a>
+              </Link>
               <div className="plan-badge">
                 {isPro ? "Pro" : isTrial ? "Trial" : "Expired"}
               </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@
 import { useState, useEffect, useRef } from "react";
 import { SignedIn, SignedOut, SignInButton, UserButton, useUser } from "@clerk/nextjs";
 import useUserPlan from "@/hooks/useUserPlan";
+import Link from "next/link";
 
 function stripFences(s = "") {
   if (!s) return "";
@@ -561,8 +562,8 @@ export default function ChatPage() {
           
           <div className="navbar-right">
             <div className="navbar-links">
-              <a href="/listings" className="billing-link">Listings</a>
-              <a href="/upgrade" className="billing-link">Upgrade</a>
+              <Link href="/listings" className="billing-link">Listings</Link>
+              <Link href="/upgrade" className="billing-link">Upgrade</Link>
             </div>
             
             <button className="new-listing-btn" onClick={() => {

--- a/pages/upgrade/success.js
+++ b/pages/upgrade/success.js
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export default function Success() {
     return (
       <div className="chat-wrap">
@@ -5,7 +7,7 @@ export default function Success() {
         <p className="chat-sub" style={{ marginBottom: 16 }}>
           Your account will update automatically. If you don’t see Pro yet, refresh the page.
         </p>
-        <a href="/chat" className="link">Back to Chat</a>
+        <Link href="/chat" className="link">Back to Chat</Link>
       </div>
     );
   }

--- a/pages/usage.js
+++ b/pages/usage.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { SignedIn, SignedOut, SignInButton } from "@clerk/nextjs";
 import useUserPlan from "@/hooks/useUserPlan";
 import NavBar from "@/components/NavBar";
+import Link from "next/link";
 
 export default function UsagePage() {
   return (
@@ -166,9 +167,9 @@ function UsageAnalytics() {
               <div style={{ fontSize: "12px", color: "var(--text-dim)", marginBottom: 8 }}>
                 Upgrade to Pro to continue using ListGenie
               </div>
-              <a href="/upgrade" className="btn" style={{ fontSize: "12px", padding: "6px 12px" }}>
+              <Link href="/upgrade" className="btn" style={{ fontSize: "12px", padding: "6px 12px" }}>
                 Upgrade Now
-              </a>
+              </Link>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- replace internal anchor tags with Next.js `Link`
- retain external anchors where applicable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: @clerk/nextjs: Missing publishableKey)*

------
https://chatgpt.com/codex/tasks/task_e_68a61882fd9c832cb4cc412b5945b51a