### PR TITLE
feat: add openrouter models api and component

### DIFF
--- a/components/OpenRouterModels.js
+++ b/components/OpenRouterModels.js
@@ -5,23 +5,29 @@ import { useEffect, useState } from "react";
 export default function OpenRouterModels() {
   const [models, setModels] = useState([]);
   const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchModels = async () => {
       try {
-        const res = await fetch("/api/openrouter");
+        const res = await fetch("/api/openrouter/models");
+        if (!res.ok) throw new Error("Request failed");
         const data = await res.json();
-
-        // ✅ FIX: use `data.data`, not `data.models`
-        setModels(data.models || data.data || []);
+        setModels(data.data || []);
       } catch (err) {
         setError("Failed to load models.");
         console.error("Error fetching models:", err);
+      } finally {
+        setLoading(false);
       }
     };
 
     fetchModels();
   }, []);
+
+  if (loading) {
+    return <p className="text-gray-500">Loading models...</p>;
+  }
 
   if (error) {
     return <p className="text-red-500">{error}</p>;

--- a/pages/api/openrouter/models.js
+++ b/pages/api/openrouter/models.js
@@ -1,0 +1,58 @@
+// /pages/api/openrouter/models.js
+// Fetches model list from OpenRouter API and returns it.
+
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+
+function getOrigin(req) {
+  const envURL =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+    process.env.VERCEL_URL;
+
+  if (envURL) {
+    return envURL.startsWith('http') ? envURL : `https://${envURL}`;
+  }
+  const host = req?.headers?.host;
+  return host ? `https://${host}` : 'http://localhost:3000';
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (!OPENROUTER_API_KEY) {
+    return res.status(500).json({ error: 'OPENROUTER_API_KEY not configured' });
+  }
+
+  const headers = {
+    Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+    'HTTP-Referer': getOrigin(req),
+    'X-Title': 'ListGenie',
+  };
+
+  let apiResponse;
+  try {
+    apiResponse = await fetch('https://openrouter.ai/api/v1/models', { headers });
+  } catch (e) {
+    console.error('OpenRouter fetch error:', e);
+    return res.status(502).json({ error: 'Upstream fetch failed' });
+  }
+
+  if (!apiResponse.ok) {
+    const text = await apiResponse.text().catch(() => '');
+    console.error('OpenRouter non-OK:', apiResponse.status, text);
+    return res.status(apiResponse.status).json({ error: text || 'OpenRouter error' });
+  }
+
+  let data;
+  try {
+    data = await apiResponse.json();
+  } catch (e) {
+    console.error('OpenRouter JSON parse error:', e);
+    return res.status(502).json({ error: 'Invalid JSON from OpenRouter' });
+  }
+
+  return res.status(200).json(data);
+}


### PR DESCRIPTION
## Summary
- add API route proxying OpenRouter models endpoint
- load models client-side with loading and error states

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: @clerk/nextjs: Missing publishableKey)


------
https://chatgpt.com/codex/tasks/task_e_68a618828034832caec16ad8bda557cf