### PR TITLE
Improve chat page layout

### DIFF
--- a/pages/chat.js
+++ b/pages/chat.js
@@ -1139,125 +1139,138 @@ export default function ChatPage() {
       </nav>
 
       <main className="chat-container">
-        {/* Examples - Compact above chat (only when not in listing mode) */}
-        {!isListingMode && (
-          <div className="examples-section compact">
-            <div className="examples-header">
-              <h3 className="examples-title">Quick Examples</h3>
-            </div>
-            <div className="examples-grid">
-              {examples.map((ex, i) => (
-                <button key={i} className="example-btn" onClick={() => setInput(ex.text)}>
-                  {ex.label}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
+        <div className="chat-wrap">
+          {/* Header */}
+          <header className="chat-header">
+            <h1 className="chat-title">AI Listing Generator</h1>
+          </header>
+          <p className="header-sub">
+            Describe your property and let AI create professional listings
+          </p>
 
-        {/* AI Chat - Main Focal Point */}
-        <div className="ai-chat-section">
-          <h1 className="ai-chat-title">AI Listing Generator</h1>
-          <p className="ai-chat-subtitle">Describe your property and let AI create professional listings</p>
-          
-          <section className="composer">
+          {/* Example prompts */}
+          {!isListingMode && (
+            <>
+              <p className="examples-label">Quick examples</p>
+              <div className="examples-row">
+                {examples.map((ex, i) => (
+                  <button
+                    key={i}
+                    className="chip example-chip"
+                    onClick={() => setInput(ex.text)}
+                  >
+                    {ex.label}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+
+          {/* Input field */}
+          <div className="field-card">
             <textarea
-              rows={2}
-              placeholder="Paste a property description or type details…"
+              className="chat-textarea"
+              rows={4}
+              placeholder="Describe your property (e.g., '3 bed ranch')"
               value={input}
               onChange={(e) => setInput(e.target.value)}
             />
-            <button className="send" disabled={loading || !input.trim()} onClick={handleSend}>
-              {loading ? "Generating…" : "Generate Listing"}
-            </button>
-          </section>
-        </div>
+            <div className="field-actions">
+              <button
+                className="send-btn"
+                disabled={loading || !input.trim()}
+                onClick={handleSend}
+              >
+                {loading ? "Generating…" : "Generate"}
+              </button>
+            </div>
+          </div>
 
-        {/* Chat Messages - Centered when present */}
-        {messages.length > 0 && (
-          <section className="chat-area">
-            {messages.map((message, index) => (
-              <div key={index} className={`message ${message.role}`}>
-                <div className="message-content">
-                  {message.role === "user" ? (
-                    <span className="user-message">{message.content}</span>
-                  ) : (
-                    <div className="assistant-message">
-                      {message.pretty || message.content || "Generating..."}
-                      
-                      {/* Show action buttons after listings */}
-                      {message.pretty && message.pretty.includes('**') && (
-                        <div className="listing-actions">
-                          <div className="primary-actions">
-                            <button 
-                              className="copy-btn"
-                              onClick={() => handleCopyListing(message.pretty)}
-                              title="Copy listing to clipboard"
-                            >
-                              📋 Copy Listing
-                            </button>
-                            <button 
-                              className="flyer-btn-small"
-                              onClick={openFlyerModal}
-                              title="Generate flyers from this listing"
-                            >
-                              🎨 Create Flyers
-                            </button>
-                          </div>
-                          
-                          <div className="modification-options">
-                            <h4 className="modify-title">Modify Listing:</h4>
-                            <div className="modify-buttons">
-                              <button 
-                                className="modify-btn"
-                                onClick={() => handleModifyListing(message.pretty, 'longer')}
-                                title="Make the listing longer and more detailed"
-                              >
-                                📝 Make Longer
-                              </button>
-                              <button 
-                                className="modify-btn"
-                                onClick={() => handleModifyListing(message.pretty, 'modern')}
-                                title="Make the listing more modern and contemporary"
-                              >
-                                🏢 More Modern
-                              </button>
-                              <button 
-                                className="modify-btn"
-                                onClick={() => handleModifyListing(message.pretty, 'country')}
-                                title="Make the listing more country/rural focused"
-                              >
-                                🌾 More Country
-                              </button>
-                              <button 
-                                className="modify-btn"
-                                onClick={() => handleModifyListing(message.pretty, 'luxurious')}
-                                title="Make the listing more luxurious and upscale"
-                              >
-                                ✨ More Luxurious
-                              </button>
-                            </div>
-                          </div>
+          {error && <div className="error-card">{error}</div>}
+
+          {/* Chat Messages - Centered when present */}
+          {messages.length > 0 && (
+            <section className="chat-area thread">
+              {messages.map((message, index) => (
+                <div key={index} className={`msg-card ${message.role}`}>
+                  <div className="msg-header">{message.role === "user" ? "You" : "ListGenie"}</div>
+                  <div className="msg-body">
+                    {message.role === "user"
+                      ? message.content
+                      : message.pretty || message.content || "Generating..."}
+                  </div>
+
+                  {message.role === "assistant" && message.pretty && message.pretty.includes('**') && (
+                    <div className="listing-actions">
+                      <div className="primary-actions">
+                        <button
+                          className="copy-btn"
+                          onClick={() => handleCopyListing(message.pretty)}
+                          title="Copy listing to clipboard"
+                        >
+                          📋 Copy Listing
+                        </button>
+                        <button
+                          className="flyer-btn-small"
+                          onClick={openFlyerModal}
+                          title="Generate flyers from this listing"
+                        >
+                          🎨 Create Flyers
+                        </button>
+                      </div>
+
+                      <div className="modification-options">
+                        <h4 className="modify-title">Modify Listing:</h4>
+                        <div className="modify-buttons">
+                          <button
+                            className="modify-btn"
+                            onClick={() => handleModifyListing(message.pretty, 'longer')}
+                            title="Make the listing longer and more detailed"
+                          >
+                            📝 Make Longer
+                          </button>
+                          <button
+                            className="modify-btn"
+                            onClick={() => handleModifyListing(message.pretty, 'modern')}
+                            title="Make the listing more modern and contemporary"
+                          >
+                            🏢 More Modern
+                          </button>
+                          <button
+                            className="modify-btn"
+                            onClick={() => handleModifyListing(message.pretty, 'country')}
+                            title="Make the listing more country/rural focused"
+                          >
+                            🌾 More Country
+                          </button>
+                          <button
+                            className="modify-btn"
+                            onClick={() => handleModifyListing(message.pretty, 'luxurious')}
+                            title="Make the listing more luxurious and upscale"
+                          >
+                            ✨ More Luxurious
+                          </button>
                         </div>
-                      )}
+                      </div>
                     </div>
                   )}
                 </div>
-              </div>
-            ))}
-            {loading && (
-              <div className="loading">
-                <div className="loading-dots">
-                  <span className="dot"></span>
-                  <span className="dot"></span>
-                  <span className="dot"></span>
+              ))}
+
+              {loading && (
+                <div className="loading">
+                  <div className="loading-dots">
+                    <span className="dot"></span>
+                    <span className="dot"></span>
+                    <span className="dot"></span>
+                  </div>
+                  <div className="loading-text">Generating your listing...</div>
                 </div>
-                <div className="loading-text">Generating your listing...</div>
-              </div>
-            )}
-            {error && <div className="error">{error}</div>}
-          </section>
-        )}
+              )}
+              {error && <div className="error">{error}</div>}
+            </section>
+          )}
+        </div>
       </main>
 
       {flyerOpen && (

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -16,7 +16,7 @@
     #0b1220;
 }
 
-.chat-wrap {
+.chat-page .chat-wrap {
   max-width: 1080px;
   margin: 0 auto;
 }
@@ -25,6 +25,7 @@
 .chat-header {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 10px;
   margin: 4px 0 10px;
 }
@@ -33,6 +34,9 @@
   line-height: 1.15;
   font-weight: 800;
   letter-spacing: 0.2px;
+  background: linear-gradient(90deg, #8b5cf6, #3b82f6);
+  -webkit-background-clip: text;
+  color: transparent;
 }
 .pro-pill {
   font-size: 12px;
@@ -76,18 +80,25 @@
 }
 
 /* Examples */
+.examples-label {
+  font-size: 13px;
+  text-transform: uppercase;
+  opacity: 0.65;
+  margin: 4px 0 8px;
+}
+
 .examples-row {
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
-  margin: 4px 0 18px;
+  justify-content: center;
+  margin: 0 0 18px;
 }
 .example-chip {
-  height: unset;
-  padding: 8px 12px;
-  font-size: 15px;
-  color: #fff; /* brighter for visibility */
-  white-space: nowrap;
+  height: 34px;
+  padding: 0 14px;
+  font-size: 14px;
+  color: #fff;
 }
 
 /* Input area */
@@ -97,7 +108,7 @@
   border-radius: 14px;
   padding: 0;
   overflow: hidden;
-  margin-bottom: 12px;
+  margin: 20px 0;
 }
 .chat-textarea {
   width: 100%;
@@ -112,7 +123,7 @@
 }
 .field-actions {
   display: flex;
-  justify-content: flex-start;
+  justify-content: flex-end;
   padding: 10px 12px 12px;
   gap: 10px;
   border-top: 1px solid var(--field-border);
@@ -124,14 +135,14 @@
   height: 40px;
   padding: 0 18px;
   border-radius: 10px;
-  border: 1px solid var(--chip-border);
-  background: var(--chip-bg);
+  border: none;
+  background: linear-gradient(90deg, #8b5cf6, #3b82f6);
   color: #fff;
   font-weight: 500;
   cursor: pointer;
-  transition: background 120ms ease, transform 80ms ease, opacity 120ms ease;
+  transition: opacity 120ms ease, transform 80ms ease;
 }
-.send-btn:hover { background: var(--chip-bg-hover); }
+.send-btn:hover { opacity: 0.9; }
 .send-btn[disabled] { opacity: 0.6; cursor: not-allowed; }
 
 /* Error surface */
@@ -160,6 +171,14 @@
   border-radius: 14px;
   padding: 14px;
   color: #fff;
+}
+.msg-card.user {
+  background: rgba(99,102,241,0.1);
+  border-color: rgba(99,102,241,0.3);
+}
+.msg-card.assistant {
+  background: rgba(16,185,129,0.1);
+  border-color: rgba(16,185,129,0.3);
 }
 .msg-header {
   font-size: 13px;

--- a/styles/components.css
+++ b/styles/components.css
@@ -59,7 +59,7 @@
   padding: 2rem 1rem;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  width: 100%;
 }
 
 
@@ -1015,14 +1015,14 @@
 }
 
 .thread {
-  max-width: 700px;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   padding: 1rem 0;
 }
 
 .listing-actions {
-  max-width: 700px;
-  margin: 2rem auto 0 auto;
+  width: 100%;
+  margin: 2rem 0 0;
   padding: 1.5rem;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -1150,18 +1150,3 @@
   }
 }
 
-/* Ensure the main chat container is centered */
-.chat-wrap {
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 0 1rem;
-}
-
-/* Center the entire page content */
-.chat-page {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  min-height: 100vh;
-  padding-top: 2rem;
-}


### PR DESCRIPTION
## Summary
- redesign chat header, examples, and input area for a wider polished layout
- add gradient styling for title and generate button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: @clerk/nextjs Missing publishableKey; export errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a62eec4178832c911c6c551d47362a