### PR TITLE
docs: clarify Clerk publishable key requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ A GPT-powered listing assistant for realtors, with Clerk authentication and Stri
 
 ## Setup
 
-1. Copy `.env.example` to `.env.local` and fill in the values.
+1. Create a `.env.local` file and include your Clerk publishable key:
+
+   ```
+   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=<your key>
+   ```
+
+   This prevents build errors like "Missing publishableKey".
 2. Run `npm install`
 3. Run `npm run dev`
 


### PR DESCRIPTION
## Summary
- document that `.env.local` must define `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` to avoid build failures

## Testing
- `npm test` *(fails: Missing script: "test")*
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=test_key npm run build` *(fails: Clerk publishableKey is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68a769a20f84832ca54646be5ea16fca