### PR TITLE
Load chat styles last and consolidate listing actions CSS

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,8 +1,8 @@
 // pages/_app.js
 import "@/styles/globals.css";
-import "@/styles/chat.css";
-import "@/styles/flyer-modal.css";
 import "@/styles/components.css";
+import "@/styles/flyer-modal.css";
+import "@/styles/chat.css";
 import { ClerkProvider, useAuth, useUser } from "@clerk/nextjs";
 import { useEffect } from "react";
 

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -186,6 +186,11 @@
   margin-top: 12px;
 }
 
+/* Chat-specific listing actions */
+.msg-card .listing-actions {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
 /* Thinking bubbles */
 .thinking {
   display: inline-flex;

--- a/styles/components.css
+++ b/styles/components.css
@@ -185,12 +185,6 @@
 }
 
 /* Listing Actions */
-.listing-actions {
-  display: flex;
-  gap: 12px;
-  margin-top: 20px;
-  flex-wrap: wrap;
-}
 
 .copy-btn {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -1021,9 +1015,12 @@
 }
 
 .listing-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
   width: 100%;
-  margin: 2rem 0 0;
-  padding: 1.5rem;
+  margin-top: 20px;
+  padding: 20px 1.5rem;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;
@@ -1073,15 +1070,6 @@
   transform: translateY(-1px);
 }
 
-/* Enhanced Listing Actions */
-.listing-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  margin-top: 20px;
-  padding-top: 20px;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-}
 
 .primary-actions {
   display: flex;


### PR DESCRIPTION
## Summary
- Load chat.css after other global styles
- Remove duplicate `.listing-actions` rules and consolidate styling
- Add chat-specific border style for listing actions inside message cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Missing publishableKey for @clerk/nextjs)*

------
https://chatgpt.com/codex/tasks/task_e_68a769a03960832c84eb908ab05cfc41