### PR TITLE
Fix syntax error in chat page

### DIFF
--- a/pages/chat.js
+++ b/pages/chat.js
@@ -711,9 +711,6 @@ export default function ChatPage() {
     }
   }
 
-    setPropertyPhotos(prev => prev.filter(photo => photo.id !== photoId));
-  }
-
   return (
     <div className="chat-page">
       <ChatHeader
@@ -802,12 +799,11 @@ export default function ChatPage() {
           </div>
         </div>
       )}
-    </div>
-  );
-}
-}
+      </div>
+    );
+  }
 
-/** ---------------- Small bits ---------------- */
+  /** ---------------- Small bits ---------------- */
 function TonePill({ value, label, current, onChange }) {
   const active = current === value;
   return (


### PR DESCRIPTION
## Summary
- remove stray property photo cleanup lines left in chat page
- restore proper component closing braces

## Testing
- `npm test`
- `npm run build` *(errors: Export encountered errors on following paths: /, /_error: /404, /_error: /500, /admin, /batch, /chat, /dashboard, /generate, /listings, /openrouter, /sign-in, /sign-up, /upgrade, /upgrade/success, /usage)*

------
https://chatgpt.com/codex/tasks/task_e_68a76dafbaa0832cbb136c7cfbd20384